### PR TITLE
Double Reviews Weight & Halve Commits

### DIFF
--- a/config/weights.json
+++ b/config/weights.json
@@ -6,13 +6,13 @@
     {
         "edgeWeights": {},
         "nodeWeights": {
-            "N\u0000sourcecred\u0000github\u0000COMMENT\u0000": 0.5,
+            "N\u0000sourcecred\u0000github\u0000COMMENT\u0000": 0.25,
             "N\u0000sourcecred\u0000github\u0000COMMIT\u0000": 1,
             "N\u0000sourcecred\u0000github\u0000ISSUE\u0000": 1,
             "N\u0000sourcecred\u0000github\u0000PULL\u0000": 16,
             "N\u0000sourcecred\u0000github\u0000PULL\u0000MetaFam\u0000metagame-wiki\u0000": 0.6,
             "N\u0000sourcecred\u0000github\u0000REPO\u0000": 4,
-            "N\u0000sourcecred\u0000github\u0000REVIEW\u0000": 2,
+            "N\u0000sourcecred\u0000github\u0000REVIEW\u0000": 4,
 
             "N\u0000sourcecred\u0000github\u0000COMMENT\u0000MetaFam\u0000assets\u0000": 0.0125,
             "N\u0000sourcecred\u0000github\u0000COMMIT\u0000MetaFam\u0000assets\u0000": 0.025,

--- a/config/weights.json
+++ b/config/weights.json
@@ -6,8 +6,8 @@
     {
         "edgeWeights": {},
         "nodeWeights": {
-            "N\u0000sourcecred\u0000github\u0000COMMENT\u0000": 0.25,
-            "N\u0000sourcecred\u0000github\u0000COMMIT\u0000": 1,
+            "N\u0000sourcecred\u0000github\u0000COMMENT\u0000": 0.5,
+            "N\u0000sourcecred\u0000github\u0000COMMIT\u0000": 0.5,
             "N\u0000sourcecred\u0000github\u0000ISSUE\u0000": 1,
             "N\u0000sourcecred\u0000github\u0000PULL\u0000": 16,
             "N\u0000sourcecred\u0000github\u0000PULL\u0000MetaFam\u0000metagame-wiki\u0000": 0.6,


### PR DESCRIPTION
A couple people have commented that they feel they're receiving an unfair amount of XP simply because they make many small atomic commits.

At the same time we have long had a persistent issue getting pull requests reviewed in a reasonable amount of time.

This pull request attempts to address both by doubling the weight of reviews (2 to 4) and halving those of commits (1 to 0.5).