### PR TITLE
Reinstated enhanced cache, changed cache key so it is regenerated

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -6,7 +6,7 @@ on:
       - master
   # As well as every 24 hours (at 0:00 UTC).
   schedule:
-    - cron: 0 */8 * * * # every 8 hours temporarily
+    - cron: 0 */12 * * * # every 12 hours temporarily
 
 jobs:
   GenerateCredInstance:
@@ -20,10 +20,10 @@ jobs:
           persist-credentials: false # Required to make github pages deployment work correctly
 
       - name: Cache Data # Cache SourceCred Data, invalidating if any of the config changes or the SC version is updated
-        uses: actions/cache@v2
+        uses: pat-s/always-upload-cache@v2.1.5
         with:
           path: '**/cache'
-          key: SC-${{ runner.os }}-${{ hashFiles('**/config.json', '**/sourcecred.json', '**/yarn.lock') }}
+          key: MG-SC-${{ runner.os }}-${{ hashFiles('**/config.json', '**/sourcecred.json', '**/yarn.lock') }}
 
       - name: Install Packages 🔧
         run: yarn --frozen-lockfile


### PR DESCRIPTION
I changed the Discord token in github actions to a newly-generated one. Apparently it didn't have all the permissions that the previous token had. Fortunately I had the old token (I think) stored, which I set as the one in github actions again.