### PR TITLE
Updating to include the new MF2 repo

### DIFF
--- a/config/plugins/sourcecred/github/config.json
+++ b/config/plugins/sourcecred/github/config.json
@@ -9,6 +9,7 @@
     "MetaFam/TheGame",
     "MetaFam/skill-bot",
     "MetaFam/assets",
-    "MetaFam/chievemints"
+    "MetaFam/chievemints",
+    "MetaFam/MetaFest2"
   ]
 }


### PR DESCRIPTION
I would like to add this repo to SourceCred so I and anyone else who works on the site gets their work picked up. I considered merging the refactored code into the interspace.chat repo but I kinda feel they should be separate repos anyway and we're not using interspace on this version. 🤷🏻  @dysbulic @alalonde any thoughts on that? bring the code from `MetaFest2` over to `interspace.chat` or keep separate?